### PR TITLE
handle session detached event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1 (2022-08-27)
+
+* Handle amqp10_event detached message when contains v1_0.error
+
 ## 0.1.0 (2022-07-26)
 
 * Initial release

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ by adding `off_broadway_amqp10` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:off_broadway_amqp10, "~> 0.1.0"}
+    {:off_broadway_amqp10, "~> 0.1.1"}
   ]
 end
 ```

--- a/lib/off_broadway_amqp10/producer.ex
+++ b/lib/off_broadway_amqp10/producer.ex
@@ -145,6 +145,19 @@ defmodule OffBroadwayAmqp10.Producer do
     {:noreply, [], new_state}
   end
 
+  def handle_info(
+        {:amqp10_event,
+         {:link, {:link_ref, :receiver, _, _},
+          {:detached, {:"v1_0.error", {:symbol, error_title}, {:utf8, error_message}, _}}}},
+        state
+      ) do
+    Logger.error(
+      "off_broadway_amqp10 session detached with error [#{error_title}], message: [#{error_message}]"
+    )
+
+    {:stop, error_title, state}
+  end
+
   def handle_info(:maybe_ask_credits, state) do
     if State.has_demand?(state) && State.receiver_attached?(state) do
       credits = State.credits_within_limits(state)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule OffBroadwayAmqp10.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
   @description "An AMQP 1.0 connector for Broadway"
   @source_url "https://github.com/highmobility/off_broadway_amqp10"
 

--- a/test/off_broadway_amqp10/producer_test.exs
+++ b/test/off_broadway_amqp10/producer_test.exs
@@ -168,6 +168,25 @@ defmodule OffBroadwayAmqp10.ProducerTest do
     end
   end
 
+  describe "amqp10 event: receiver detached" do
+    test "set the receiver status", %{state: state} do
+      msg =
+        {:amqp10_event,
+         {:link, {:link_ref, :receiver, self(), 0},
+          {:detached,
+           {:"v1_0.error", {:symbol, "amqp:internal-error"},
+            {:utf8,
+             "The service was unable to process the request; please retry the operation. For more information on exception types and proper exception handling, please refer to http://go.microsoft.com/fwlink/?LinkId=761101 TrackingId:abcdef1234443_G8, SystemTracker:gateway5, Timestamp:2022-08-12T17:54:41"},
+            :undefined}}}}
+
+      assert {:stop, "amqp:internal-error", new_state} =
+               SUT.handle_info(
+                 msg,
+                 state
+               )
+    end
+  end
+
   describe "amqp10 event: credit exhausted" do
     test "invoke maybe ask credits", %{state: state} do
       assert {:noreply, [], new_state} =


### PR DESCRIPTION
it logs the error and send the genserver to the stop state

in ~feature~ future we might allow a Backoff but  for now it's good enough if the process is restarted by the supervisor 