### PR TITLE
handle when connection closed forcefully

### DIFF
--- a/lib/off_broadway_amqp10/producer.ex
+++ b/lib/off_broadway_amqp10/producer.ex
@@ -105,6 +105,15 @@ defmodule OffBroadwayAmqp10.Producer do
     {:noreply, [], new_state}
   end
 
+  def handle_info(
+        {:amqp10_event, {:connection, _, {:closed, {:forced, error_message}}}},
+        state
+      ) do
+    Logger.error("off_broadway_amqp10 connection closed forcfully, message: [#{error_message}]")
+
+    {:stop, :connection_closed_forcfully, state}
+  end
+
   def handle_info(:begin_session, state) do
     log_command("begin session")
 

--- a/lib/off_broadway_amqp10/producer.ex
+++ b/lib/off_broadway_amqp10/producer.ex
@@ -105,6 +105,7 @@ defmodule OffBroadwayAmqp10.Producer do
     {:noreply, [], new_state}
   end
 
+  @impl GenStage
   def handle_info(
         {:amqp10_event, {:connection, _, {:closed, {:forced, error_message}}}},
         state
@@ -114,6 +115,7 @@ defmodule OffBroadwayAmqp10.Producer do
     {:stop, :connection_closed_forcefully, state}
   end
 
+  @impl GenStage
   def handle_info(:begin_session, state) do
     log_command("begin session")
 
@@ -124,6 +126,7 @@ defmodule OffBroadwayAmqp10.Producer do
     {:noreply, [], new_state}
   end
 
+  @impl GenStage
   def handle_info({:amqp10_event, {:session, _, :begun}}, state) do
     log_event("session begun")
 
@@ -134,6 +137,7 @@ defmodule OffBroadwayAmqp10.Producer do
     {:noreply, [], new_state}
   end
 
+  @impl GenStage
   def handle_info(:attach_receiver, state) do
     log_command("attach")
 
@@ -144,6 +148,7 @@ defmodule OffBroadwayAmqp10.Producer do
     {:noreply, [], new_state}
   end
 
+  @impl GenStage
   def handle_info({:amqp10_event, {:link, {:link_ref, :receiver, _, _}, :attached}}, state) do
     log_event("attached")
 
@@ -154,6 +159,7 @@ defmodule OffBroadwayAmqp10.Producer do
     {:noreply, [], new_state}
   end
 
+  @impl GenStage
   def handle_info(
         {:amqp10_event,
          {:link, {:link_ref, :receiver, _, _},
@@ -167,6 +173,7 @@ defmodule OffBroadwayAmqp10.Producer do
     {:stop, error_title, state}
   end
 
+  @impl GenStage
   def handle_info(:maybe_ask_credits, state) do
     if State.has_demand?(state) && State.receiver_attached?(state) do
       credits = State.credits_within_limits(state)
@@ -178,6 +185,7 @@ defmodule OffBroadwayAmqp10.Producer do
     {:noreply, [], state}
   end
 
+  @impl GenStage
   def handle_info(
         {:amqp10_event, {:link, {:link_ref, :receiver, _, _}, :credit_exhausted}},
         state
@@ -189,6 +197,7 @@ defmodule OffBroadwayAmqp10.Producer do
     {:noreply, [], state}
   end
 
+  @impl GenStage
   def handle_info({:amqp10_msg, {:link_ref, :receiver, _, _}, msg}, state) do
     client_module = state.amqp.client_module
     payload = client_module.body(msg)

--- a/lib/off_broadway_amqp10/producer.ex
+++ b/lib/off_broadway_amqp10/producer.ex
@@ -109,9 +109,9 @@ defmodule OffBroadwayAmqp10.Producer do
         {:amqp10_event, {:connection, _, {:closed, {:forced, error_message}}}},
         state
       ) do
-    Logger.error("off_broadway_amqp10 connection closed forcfully, message: [#{error_message}]")
+    Logger.error("off_broadway_amqp10 connection closed forcefully, message: [#{error_message}]")
 
-    {:stop, :connection_closed_forcfully, state}
+    {:stop, :connection_closed_forcefully, state}
   end
 
   def handle_info(:begin_session, state) do

--- a/test/off_broadway_amqp10/producer_test.exs
+++ b/test/off_broadway_amqp10/producer_test.exs
@@ -199,7 +199,7 @@ defmodule OffBroadwayAmqp10.ProducerTest do
             "The connection was inactive for more than the allowed 300000 milliseconds and is closed by container 'LinkTracker'. TrackingId:abc, SystemTracker:gateway5, Timestamp:2022-12-13T01:04:38"}}}}
 
       assert capture_log(fn ->
-               assert {:stop, :connection_closed_forcfully, _new_state} =
+               assert {:stop, :connection_closed_forcefully, _new_state} =
                         SUT.handle_info(
                           msg,
                           state


### PR DESCRIPTION
When receive connection close event:

1. Log the error message when the connection is closed from the server due to some timeouts.
2. exit with `:connection_closed_forcfully` in this case.


