### PR TITLE
Allow SASL to be set to :none and durable to be configured by user

### DIFF
--- a/lib/off_broadway_amqp10/amqp_10_client/state.ex
+++ b/lib/off_broadway_amqp10/amqp_10_client/state.ex
@@ -96,14 +96,24 @@ defmodule OffBroadwayAmqp10.Amqp10.State do
       hostname: get_in(opts, [:connection, :hostname]),
       address: String.to_charlist(get_in(opts, [:connection, :hostname])),
       port: get_in(opts, [:connection, :port]),
-      sasl: {
-        get_in(opts, [:connection, :sasl, :mechanism]),
-        get_in(opts, [:connection, :sasl, :username]),
-        get_in(opts, [:connection, :sasl, :password])
-      },
+      sasl: sasl_config(opts),
       tls_opts: get_in(opts, [:connection, :tls_opts]),
       transfer_limit_margin: get_in(opts, [:connection, :transfer_limit_margin])
     }
+  end
+
+  defp sasl_config(opts) do
+    case get_in(opts, [:connection, :sasl]) do
+      :none ->
+        :none
+
+      _ ->
+        {
+          get_in(opts, [:connection, :sasl, :mechanism]),
+          get_in(opts, [:connection, :sasl, :username]),
+          get_in(opts, [:connection, :sasl, :password])
+        }
+    end
   end
 
   defp receiver_config(opts) do

--- a/lib/off_broadway_amqp10/amqp_10_client/state.ex
+++ b/lib/off_broadway_amqp10/amqp_10_client/state.ex
@@ -96,24 +96,20 @@ defmodule OffBroadwayAmqp10.Amqp10.State do
       hostname: get_in(opts, [:connection, :hostname]),
       address: String.to_charlist(get_in(opts, [:connection, :hostname])),
       port: get_in(opts, [:connection, :port]),
-      sasl: sasl_config(opts),
+      sasl: sasl_config(get_in(opts, [:connection, :sasl])),
       tls_opts: get_in(opts, [:connection, :tls_opts]),
       transfer_limit_margin: get_in(opts, [:connection, :transfer_limit_margin])
     }
   end
 
-  defp sasl_config(opts) do
-    case get_in(opts, [:connection, :sasl]) do
-      :none ->
-        :none
+  defp sasl_config(:none), do: :none
 
-      _ ->
-        {
-          get_in(opts, [:connection, :sasl, :mechanism]),
-          get_in(opts, [:connection, :sasl, :username]),
-          get_in(opts, [:connection, :sasl, :password])
-        }
-    end
+  defp sasl_config(sasl_opts) do
+    {
+      Keyword.get(sasl_opts, :mechanism),
+      Keyword.get(sasl_opts, :username),
+      Keyword.get(sasl_opts, :password)
+    }
   end
 
   defp receiver_config(opts) do

--- a/lib/off_broadway_amqp10/amqp_10_client/state.ex
+++ b/lib/off_broadway_amqp10/amqp_10_client/state.ex
@@ -119,7 +119,12 @@ defmodule OffBroadwayAmqp10.Amqp10.State do
   defp receiver_config(opts) do
     %{
       name: get_in(opts, [:session, :name]),
-      role: {:receiver, %{address: get_in(opts, [:queue]), durable: :none}, self()},
+      role:
+        {:receiver,
+         %{
+           address: get_in(opts, [:queue]),
+           durable: get_in(opts, [:durable])
+         }, self()},
       snd_settle_mode: get_in(opts, [:session, :snd_settle_mode]),
       rcv_settle_mode: get_in(opts, [:session, :rcv_settle_mode]),
       filter: %{},

--- a/lib/off_broadway_amqp10/producer.ex
+++ b/lib/off_broadway_amqp10/producer.ex
@@ -19,6 +19,7 @@ defmodule OffBroadwayAmqp10.Producer do
           module:
             {OffBroadwayAmqp10.Producer,
             queue: "my_queue",
+            durable: :none,
             connection: [
               hostname: "my-service.servicebus.windows.net",
               sasl: [mechanism: :plain, username: "foo", password: "bar"],

--- a/lib/off_broadway_amqp10/producer.ex
+++ b/lib/off_broadway_amqp10/producer.ex
@@ -26,7 +26,9 @@ defmodule OffBroadwayAmqp10.Producer do
               transfer_limit_margin: 100
             ],
             session: [
-              name: to_string(node())
+              name: to_string(node()),
+              snd_settle_mode: :mixed,
+              rcv_settle_mode: :second
             ]},
           concurrency: 1
         ],

--- a/lib/off_broadway_amqp10/producer/params.ex
+++ b/lib/off_broadway_amqp10/producer/params.ex
@@ -4,24 +4,29 @@ defmodule OffBroadwayAmqp10.Producer.Params do
     hostname: [type: :string, required: true, doc: "The hostname"],
     port: [type: :pos_integer, required: true, doc: "The port number"],
     sasl: [
-      type: :keyword_list,
-      keys: [
-        mechanism: [
-          type: {:in, [:plain]},
-          required: true
-        ],
-        username: [
-          type: :string,
-          required: true
-        ],
-        password: [
-          type: :string,
-          required: true
-        ]
-      ],
+      type:
+        {:or,
+         [
+           {:in, [:none]},
+           {:keyword_list,
+            [
+              mechanism: [
+                type: {:in, [:plain]},
+                required: true
+              ],
+              username: [
+                type: :string,
+                required: true
+              ],
+              password: [
+                type: :string,
+                required: true
+              ]
+            ]}
+         ]},
       required: true,
       doc: """
-      [mechanism: :plain, username: "foo", password: "bar"]. In Azure Service Bus username is `SharedAccessKeyName` and password is `SharedAccessKey`
+      :none or [mechanism: :plain, username: "foo", password: "bar"]. In Azure Service Bus username is `SharedAccessKeyName` and password is `SharedAccessKey`
       """
     ],
     tls_opts: [type: :any, required: false],

--- a/lib/off_broadway_amqp10/producer/params.ex
+++ b/lib/off_broadway_amqp10/producer/params.ex
@@ -76,6 +76,14 @@ defmodule OffBroadwayAmqp10.Producer.Params do
       The name of the queue or topic
       """
     ],
+    durable: [
+      type: {:in, [:none, :configuration, :unsettled_state]},
+      required: false,
+      default: :none,
+      doc: """
+      Receiver durability option based on `t::amqp10_client_session.terminus_durability/0``
+      """
+    ],
     connection: [
       type: :keyword_list,
       keys: @connection_opts_schema,

--- a/test/off_broadway_amqp10/producer/params_test.exs
+++ b/test/off_broadway_amqp10/producer/params_test.exs
@@ -3,29 +3,34 @@ defmodule OffBroadwayAmqp10.Producer.ParamsTest do
 
   alias OffBroadwayAmqp10.Producer.Params, as: SUT
 
+  @connection_opts [
+    hostname: "localhost",
+    port: 5671,
+    sasl: [
+      mechanism: :plain,
+      username: "foo",
+      password: "bar"
+    ]
+  ]
+  @session_opts [
+    name: "some_session_name",
+    snd_settle_mode: :mixed,
+    rcv_settle_mode: :second
+  ]
+
+  @opts [
+    queue: "some_queue",
+    connection: @connection_opts,
+    session: @session_opts,
+    client_module: OffBroadwayAmqp10.Amqp10.Client.Impl
+  ]
+
   test "validates configuration" do
-    connection_opts = [
-      hostname: "localhost",
-      port: 5671,
-      sasl: [
-        mechanism: :plain,
-        username: "foo",
-        password: "bar"
-      ]
-    ]
+    assert SUT.validate!(@opts)
+  end
 
-    session_opts = [
-      name: "some_session_name",
-      snd_settle_mode: :mixed,
-      rcv_settle_mode: :second
-    ]
-
-    opts = [
-      queue: "some_queue",
-      connection: connection_opts,
-      session: session_opts,
-      client_module: OffBroadwayAmqp10.Amqp10.Client.Impl
-    ]
+  test "validates configuration using sasl: none" do
+    opts = put_in(@opts, [:connection, :sasl], :none)
 
     assert SUT.validate!(opts)
   end

--- a/test/off_broadway_amqp10/producer/params_test.exs
+++ b/test/off_broadway_amqp10/producer/params_test.exs
@@ -34,4 +34,12 @@ defmodule OffBroadwayAmqp10.Producer.ParamsTest do
 
     assert SUT.validate!(opts)
   end
+
+  test "validates configuration with durable key" do
+    durable = :configuration
+    opts = Keyword.put(@opts, :durable, durable)
+
+    assert result = SUT.validate!(opts)
+    assert {:ok, ^durable} = Keyword.fetch(result, :durable)
+  end
 end

--- a/test/off_broadway_amqp10/producer_test.exs
+++ b/test/off_broadway_amqp10/producer_test.exs
@@ -181,7 +181,7 @@ defmodule OffBroadwayAmqp10.ProducerTest do
              "The service was unable to process the request; please retry the operation. For more information on exception types and proper exception handling, please refer to http://go.microsoft.com/fwlink/?LinkId=761101 TrackingId:abcdef1234443_G8, SystemTracker:gateway5, Timestamp:2022-08-12T17:54:41"},
             :undefined}}}}
 
-      assert {:stop, "amqp:internal-error", new_state} =
+      assert {:stop, "amqp:internal-error", _new_state} =
                SUT.handle_info(
                  msg,
                  state


### PR DESCRIPTION
This PR allows the user of specify the durability for the receiver and the option none to SASL.

Durable Options:
* https://hexdocs.pm/amqp10_client/amqp10_client_session.html#type-terminus_durability

SASL Options(we currently only support `encrypted_sasl`):
* https://hexdocs.pm/amqp10_client/amqp10_client_connection.html#type-decrypted_sasl