### PR TITLE
Implement support for body of type #'v1_0.amqp_value'{}

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ end
 - [ ] Handle connection errors
 - [ ] Handle session errors
 - [ ] Backoff strategy to re-connect in case of an error
+- [ ] Handle body type: `[#'v1_0.amqp_sequence'{}]` specified in this [doc](https://hexdocs.pm/amqp10_client/amqp10_msg.html#body-1) and this [PR](https://github.com/highmobility/off_broadway_amqp10/pull/114).

--- a/lib/off_broadway_amqp10/amqp_10_client/client_impl.ex
+++ b/lib/off_broadway_amqp10/amqp_10_client/client_impl.ex
@@ -12,7 +12,9 @@ defmodule OffBroadwayAmqp10.Amqp10.Client.Impl do
   Record.defrecord(
     :amqp_value,
     @amqp_value_record_tag,
-    Record.extract(@amqp_value_record_tag, from: "deps/amqp10_common/include/amqp10_framing.hrl")
+    Record.extract(@amqp_value_record_tag,
+      from: Path.join(:code.lib_dir(:amqp10_common), "include/amqp10_framing.hrl")
+    )
   )
 
   @behaviour Client

--- a/lib/off_broadway_amqp10/amqp_10_client/client_impl.ex
+++ b/lib/off_broadway_amqp10/amqp_10_client/client_impl.ex
@@ -3,14 +3,16 @@ defmodule OffBroadwayAmqp10.Amqp10.Client.Impl do
   AMQP Client Wrapper
   """
 
-  alias OffBroadwayAmqp10.Amqp10.State
-  alias OffBroadwayAmqp10.Amqp10.Client
+  alias OffBroadwayAmqp10.Amqp10.{Client, State}
 
   require Record
 
+  @amqp_value_record_tag :"v1_0.amqp_value"
+
   Record.defrecord(
-    :amqp10_value,
-    Record.extract(:"v1_0.amqp_value", from: "deps/amqp10_common/include/amqp10_framing.hrl")
+    :amqp_value,
+    @amqp_value_record_tag,
+    Record.extract(@amqp_value_record_tag, from: "deps/amqp10_common/include/amqp10_framing.hrl")
   )
 
   @behaviour Client
@@ -48,8 +50,8 @@ defmodule OffBroadwayAmqp10.Amqp10.Client.Impl do
       match?([_], body) ->
         List.first(body)
 
-      Record.is_record(body, :amqp10_value) ->
-        packed_content = amqp10_value(body, :content)
+      Record.is_record(body, @amqp_value_record_tag) ->
+        packed_content = amqp_value(body, :content)
         :amqp10_client_types.unpack(packed_content)
     end
   end

--- a/lib/off_broadway_amqp10/amqp_10_client/client_impl.ex
+++ b/lib/off_broadway_amqp10/amqp_10_client/client_impl.ex
@@ -7,14 +7,14 @@ defmodule OffBroadwayAmqp10.Amqp10.Client.Impl do
 
   require Record
 
+  @hrl_path Path.join(:code.lib_dir(:amqp10_common), "include/amqp10_framing.hrl")
+
   @amqp_value_record_tag :"v1_0.amqp_value"
 
   Record.defrecord(
     :amqp_value,
     @amqp_value_record_tag,
-    Record.extract(@amqp_value_record_tag,
-      from: Path.join(:code.lib_dir(:amqp10_common), "include/amqp10_framing.hrl")
-    )
+    Record.extract(@amqp_value_record_tag, from: @hrl_path)
   )
 
   @amqp_sequence_record_tag :"v1_0.amqp_sequence"
@@ -22,9 +22,7 @@ defmodule OffBroadwayAmqp10.Amqp10.Client.Impl do
   Record.defrecord(
     :amqp_sequence,
     @amqp_sequence_record_tag,
-    Record.extract(@amqp_sequence_record_tag,
-      from: Path.join(:code.lib_dir(:amqp10_common), "include/amqp10_framing.hrl")
-    )
+    Record.extract(@amqp_sequence_record_tag, from: @hrl_path)
   )
 
   @behaviour Client

--- a/lib/off_broadway_amqp10/amqp_10_client/client_impl.ex
+++ b/lib/off_broadway_amqp10/amqp_10_client/client_impl.ex
@@ -17,6 +17,16 @@ defmodule OffBroadwayAmqp10.Amqp10.Client.Impl do
     )
   )
 
+  @amqp_sequence_record_tag :"v1_0.amqp_sequence"
+
+  Record.defrecord(
+    :amqp_sequence,
+    @amqp_sequence_record_tag,
+    Record.extract(@amqp_sequence_record_tag,
+      from: Path.join(:code.lib_dir(:amqp10_common), "include/amqp10_framing.hrl")
+    )
+  )
+
   @behaviour Client
 
   @impl Client
@@ -49,12 +59,15 @@ defmodule OffBroadwayAmqp10.Amqp10.Client.Impl do
     body = :amqp10_msg.body(raw_msg)
 
     cond do
-      match?([_], body) ->
-        List.first(body)
-
       Record.is_record(body, @amqp_value_record_tag) ->
         packed_content = amqp_value(body, :content)
         :amqp10_client_types.unpack(packed_content)
+
+      match?([value] when is_binary(value), body) ->
+        List.first(body)
+
+      is_list(body) && Record.is_record(List.first(body), @amqp_sequence_record_tag) ->
+        raise "Not implemented - AMQP 1.0 Sequence is not implemented - Please create an issue with a sample message if you need it"
     end
   end
 

--- a/test/off_broadway_amqp10/amqp10_client/client_impl_test.exs
+++ b/test/off_broadway_amqp10/amqp10_client/client_impl_test.exs
@@ -11,6 +11,12 @@ defmodule OffBroadwayAmqp10.Amqp10.Client.ImplTest do
     test "v1_0.amqp_value: extracts body" do
       assert SUT.body(Fixture.raw_msg_amqp10_value()) == "Itachi"
     end
+
+    test "v1_0.amqp_sequence list: raises" do
+      assert_raise RuntimeError, ~r/Not implemented - AMQP 1.0 Sequence is not implemented/, fn ->
+        SUT.body(Fixture.raw_msg_amqp10_sequence())
+      end
+    end
   end
 
   describe "headers/1" do

--- a/test/off_broadway_amqp10/amqp10_client/client_impl_test.exs
+++ b/test/off_broadway_amqp10/amqp10_client/client_impl_test.exs
@@ -4,8 +4,12 @@ defmodule OffBroadwayAmqp10.Amqp10.Client.ImplTest do
   alias OffBroadwayAmqp10.Amqp10.Client.Impl, as: SUT
 
   describe "body/1" do
-    test "extracts body" do
+    test "binary list: extracts body" do
       assert SUT.body(Fixture.raw_msg()) == "Itachi"
+    end
+
+    test "v1_0.amqp_value: extracts body" do
+      assert SUT.body(Fixture.raw_msg_amqp10_value()) == "Itachi"
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,8 @@
 ExUnit.start()
 
 defmodule Fixture do
+  require OffBroadwayAmqp10.Amqp10.Client.Impl
+
   def configuration(opts \\ []) do
     connection_opts = [
       hostname: "localhost",
@@ -37,8 +39,8 @@ defmodule Fixture do
     OffBroadwayAmqp10.Producer.State.new(configuration(opts))
   end
 
-  def raw_msg do
-    raw_msg = :amqp10_msg.new("delivery_tag", "Itachi")
+  def raw_msg(value \\ "Itachi") do
+    raw_msg = :amqp10_msg.new("delivery_tag", value)
     raw_msg = :amqp10_msg.set_headers(%{:durable => false, priority: 4}, raw_msg)
 
     raw_msg =
@@ -64,6 +66,12 @@ defmodule Fixture do
       },
       raw_msg
     )
+  end
+
+  def raw_msg_amqp10_value do
+    value = :amqp10_client_types.utf8("Itachi")
+    record = OffBroadwayAmqp10.Amqp10.Client.Impl.amqp10_value(content: value)
+    raw_msg(record)
   end
 end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -70,7 +70,7 @@ defmodule Fixture do
 
   def raw_msg_amqp10_value do
     value = :amqp10_client_types.utf8("Itachi")
-    record = OffBroadwayAmqp10.Amqp10.Client.Impl.amqp10_value(content: value)
+    record = OffBroadwayAmqp10.Amqp10.Client.Impl.amqp_value(content: value)
     raw_msg(record)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -73,6 +73,16 @@ defmodule Fixture do
     record = OffBroadwayAmqp10.Amqp10.Client.Impl.amqp_value(content: value)
     raw_msg(record)
   end
+
+  def raw_msg_amqp10_sequence do
+    values = [
+      :amqp10_client_types.utf8("Itachi"),
+      :amqp10_client_types.utf8("Shisui")
+    ]
+
+    records = [OffBroadwayAmqp10.Amqp10.Client.Impl.amqp_sequence(content: values)]
+    raw_msg(records)
+  end
 end
 
 defmodule FakeAmqpClient do


### PR DESCRIPTION
Doc: https://hexdocs.pm/amqp10_client/amqp10_msg.html#body-1

The previous version supported only a binary list with a single item, this PR adds supports for the `#'v1_0.amqp_value'{}` record.

ℹ️ This PR doesn't add support to `[#'v1_0.amqp_sequence'{}]`.